### PR TITLE
fix(marked-format): add console.error to catch clause

### DIFF
--- a/packages/code-format/src/index.ts
+++ b/packages/code-format/src/index.ts
@@ -50,7 +50,9 @@ export default function markedCodeFormat(
             ? (inlineOptions as prettier.Options)
             : {})
         })
-      } catch {}
+      } catch (e) {
+        console.error(e)
+      }
     }
   }
 }


### PR DESCRIPTION
marked format doesn't log error which is thrown by prettier.format. It is not obvious why the plugin does not work. It if would log the error, then right away we'd have a notion that something is not ok.