### PR TITLE
marked-plaintify port to Marked v13

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@types/react-dom": "^18.2.25",
         "@types/set-value": "^4.0.3",
         "doogu": "^3.2.13",
-        "marked": "^12.0.2",
+        "marked": "^13.0.2",
         "prettier-plugin-svelte": "^3.2.3",
         "pupa": "^3.1.0",
         "react-dom": "^18.2.0",
@@ -3549,9 +3549,10 @@
       }
     },
     "node_modules/marked": {
-      "version": "12.0.2",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-12.0.2.tgz",
-      "integrity": "sha512-qXUm7e/YKFoqFPYPa3Ukg9xlI5cyAtGmyEIzMfW//m6kXwCy2Ps9DYf5ioijFKQ8qyuscrHoY04iJGctu2Kg0Q==",
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-13.0.2.tgz",
+      "integrity": "sha512-J6CPjP8pS5sgrRqxVRvkCIkZ6MFdRIjDkwUwgJ9nL2fbmM6qGQeB2C16hi8Cc9BOzj6xXzy0jyi0iPIfnMHYzA==",
+      "license": "MIT",
       "bin": {
         "marked": "bin/marked.js"
       },

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@types/react-dom": "^18.2.25",
     "@types/set-value": "^4.0.3",
     "doogu": "^3.2.13",
-    "marked": "^12.0.2",
+    "marked": "^13.0.2",
     "prettier-plugin-svelte": "^3.2.3",
     "pupa": "^3.1.0",
     "react-dom": "^18.2.0",

--- a/packages/plaintify/src/index.ts
+++ b/packages/plaintify/src/index.ts
@@ -18,7 +18,7 @@ export default function markedPlaintify(
   options: Options = {}
 ): MarkedExtension {
   const plainTextRenderer: Options = {}
-  const mdIgnores: string[] = ['constructor', 'hr', 'checkbox', 'br']
+  const mdIgnores: string[] = ['constructor', 'hr', 'checkbox ', 'br', 'space']
   const mdInlines: string[] = ['strong', 'em', 'codespan', 'del', 'text']
   const mdEscapes: string[] = ['html', 'code', 'codespan']
 

--- a/packages/plaintify/src/index.ts
+++ b/packages/plaintify/src/index.ts
@@ -145,7 +145,11 @@ export default function markedPlaintify(
       }
     } else {
       // handle other elements
-      plainTextRenderer[prop] = token => token.text
+      plainTextRenderer[prop] = token => {
+        return 'tokens' in token && token.tokens
+          ? parser.parseInline(token.tokens)
+          : token.text
+      }
     }
   })
 

--- a/packages/plaintify/src/index.ts
+++ b/packages/plaintify/src/index.ts
@@ -1,4 +1,10 @@
-import { Renderer, MarkedExtension, RendererObject } from 'marked'
+import {
+  Renderer,
+  MarkedExtension,
+  RendererObject,
+  Marked,
+  marked
+} from 'marked'
 
 /**
  * Options for configuring the markedPlaintify extension.
@@ -15,8 +21,10 @@ export type Options = RendererObject & {
  * A [marked](https://marked.js.org/) extension to convert Markdown to Plaintext.
  */
 export default function markedPlaintify(
+  instance: Marked | typeof marked,
   options: Options = {}
 ): MarkedExtension {
+  const parser = instance.Parser
   const plainTextRenderer: Options = {}
   const mdIgnores: string[] = ['constructor', 'hr', 'checkbox ', 'br', 'space']
   const mdInlines: string[] = ['strong', 'em', 'codespan', 'del', 'text']

--- a/packages/plaintify/src/index.ts
+++ b/packages/plaintify/src/index.ts
@@ -54,6 +54,11 @@ export default function markedPlaintify(
         let text = ''
         for (let j = 0; j < token.items.length; j++) {
           const item = token.items[j]
+          // @ts-expect-error In my opinion, 'listitem' will ever be
+          // undefined nor the 'this' issue has any implications. We're
+          // declaring functions and passing them to Marked for later use.
+          // When the function is executed this object will have everything
+          // it needs to work well.
           text += plainTextRenderer.listitem(item).replace(/\n{2,}/g, '\n')
         }
 
@@ -78,6 +83,7 @@ export default function markedPlaintify(
 
         // parsing headers
         for (let j = 0; j < token.header.length; j++) {
+          // @ts-expect-error See 'list' function error
           plainTextRenderer.tablecell(token.header[j])
         }
 
@@ -87,8 +93,10 @@ export default function markedPlaintify(
           const row = token.rows[j]
           let cell = ''
           for (let k = 0; k < row.length; k++) {
+            // @ts-expect-error See 'list' function error
             cell += plainTextRenderer.tablecell(row[k])
           }
+          // @ts-expect-error See 'list' function error
           body += plainTextRenderer.tablerow({ text: cell })
         }
 

--- a/packages/plaintify/src/index.ts
+++ b/packages/plaintify/src/index.ts
@@ -27,8 +27,8 @@ export default function markedPlaintify(
   const parser = instance.Parser
   const plainTextRenderer: Options = {}
   const mdIgnores: string[] = ['constructor', 'hr', 'checkbox ', 'br', 'space']
-  const mdInlines: string[] = ['strong', 'em', 'codespan', 'del', 'text']
-  const mdEscapes: string[] = ['html', 'code', 'codespan']
+  const mdInlines: string[] = ['strong', 'em', 'del']
+  const mdEscapes: string[] = ['html', 'code']
 
   let currentTableHeader: string[] = []
 
@@ -38,29 +38,66 @@ export default function markedPlaintify(
       plainTextRenderer[prop] = () => ''
     } else if (mdInlines.includes(prop)) {
       // preserve inline elements
-      plainTextRenderer[prop] = text => text
+      plainTextRenderer[prop] = token => {
+        const text = parser.parseInline(token.tokens)
+        return text
+      }
     } else if (mdEscapes.includes(prop)) {
       // escaped elements
-      plainTextRenderer[prop] = text => escapeHTML(text) + '\n\n'
+      plainTextRenderer[prop] = token => escapeHTML(token.text) + '\n\n'
+    } else if (prop === 'codespan') {
+      // handle codespan
+      plainTextRenderer[prop] = token => escapeHTML(token.text)
     } else if (prop === 'list') {
       // handle list element
-      plainTextRenderer[prop] = text => '\n' + text.trim() + '\n\n'
+      plainTextRenderer[prop] = token => {
+        let text = ''
+        for (let j = 0; j < token.items.length; j++) {
+          const item = token.items[j]
+          text += plainTextRenderer.listitem(item).replace(/\n{2,}/g, '\n')
+        }
+
+        return '\n' + text.trim() + '\n\n'
+      }
     } else if (prop === 'listitem') {
       // handle list items
-      plainTextRenderer[prop] = text => '\n' + text.trim()
+      plainTextRenderer[prop] = token => {
+        const text = parser.parse(token.tokens)
+        return '\n' + text.trim()
+      }
     } else if (prop === 'blockquote') {
-      // handle list items
-      plainTextRenderer[prop] = text => text.trim() + '\n\n'
+      // handle blockquote
+      plainTextRenderer[prop] = token => {
+        const text = parser.parse(token.tokens)
+        return text.trim() + '\n\n'
+      }
     } else if (prop === 'table') {
       // handle table elements
-      plainTextRenderer[prop] = (_, body) => {
+      plainTextRenderer[prop] = token => {
         currentTableHeader = []
+
+        // parsing headers
+        for (let j = 0; j < token.header.length; j++) {
+          plainTextRenderer.tablecell(token.header[j])
+        }
+
+        // parsing rows
+        let body = ''
+        for (let j = 0; j < token.rows.length; j++) {
+          const row = token.rows[j]
+          let cell = ''
+          for (let k = 0; k < row.length; k++) {
+            cell += plainTextRenderer.tablecell(row[k])
+          }
+          body += plainTextRenderer.tablerow({ text: cell })
+        }
+
         return body
       }
     } else if (prop === 'tablerow') {
       // handle table rows
-      plainTextRenderer[prop] = content => {
-        const chunks = content.split('__CELL_PAD__').filter(Boolean)
+      plainTextRenderer[prop] = token => {
+        const chunks = token.text.split('__CELL_PAD__').filter(Boolean)
 
         return (
           currentTableHeader
@@ -70,22 +107,50 @@ export default function markedPlaintify(
       }
     } else if (prop === 'tablecell') {
       // handle table cells
-      plainTextRenderer[prop] = (text, flags) => {
-        if (flags.header) {
+      plainTextRenderer[prop] = token => {
+        const text = parser.parseInline(token.tokens)
+
+        if (token.header) {
           currentTableHeader.push(text)
         }
+
         return text + '__CELL_PAD__'
       }
-    } else if (prop === 'link' || prop === 'image') {
-      // handle links and images
-      plainTextRenderer[prop] = (_, __, text) => (!!text ? text : '')
+    } else if (prop === 'link') {
+      // handle links
+      plainTextRenderer[prop] = token => {
+        const text = parser.parseInline(token.tokens)
+        return text + '\n\n'
+      }
+    } else if (prop === 'image') {
+      // handle images (links starting with !)
+      plainTextRenderer[prop] = token => {
+        return token.text + '\n\n'
+      }
+    } else if (prop === 'paragraph') {
+      // handle paragraphs (which sometimes link and images lines are detected as well)
+      plainTextRenderer[prop] = token => {
+        let text = parser.parseInline(token.tokens)
+
+        // Removing extra newlines introduced by other renderer functions
+        text = text.replace(/\n{2,}/g, '')
+
+        return text + '\n\n'
+      }
+    } else if (prop === 'heading') {
+      // handle headings
+      plainTextRenderer[prop] = token => {
+        const text = parser.parseInline(token.tokens)
+        return text + '\n\n'
+      }
     } else {
-      // handle other (often block-level) elements
-      plainTextRenderer[prop] = text => text + '\n\n'
+      // handle other elements
+      plainTextRenderer[prop] = token => token.text
     }
   })
 
   return {
+    useNewRenderer: true,
     renderer: {
       ...plainTextRenderer,
       ...options

--- a/packages/plaintify/test/fixtures/complex.md
+++ b/packages/plaintify/test/fixtures/complex.md
@@ -23,7 +23,8 @@ _This will also be italic_
 - Item 1
 - Item 2
   - Item 2a
-  - Item 2b
+  - **Item 2b** (bold)
+- _Item 3_ (italics)
 
 ### Ordered List
 

--- a/packages/plaintify/test/index.test.ts
+++ b/packages/plaintify/test/index.test.ts
@@ -6,7 +6,7 @@ import markedPlaintify from '../src/index.js'
 
 it('should convert Markdown content to plain text', () => {
   const md = readFileSync('test/fixtures/base.md', 'utf8')
-  const plaintext = marked.use({ gfm: true }, markedPlaintify()).parse(md)
+  const plaintext = marked.use({ gfm: true }, markedPlaintify(marked)).parse(md)
 
   expect(plaintext).toMatchInlineSnapshot(`
     "Heading 1
@@ -30,7 +30,7 @@ it('should convert Markdown content to plain text', () => {
 
 it('should handle complex Markdown content', () => {
   const md = readFileSync('test/fixtures/complex.md', 'utf8')
-  const plaintext = marked.use({ gfm: true }, markedPlaintify()).parse(md)
+  const plaintext = marked.use({ gfm: true }, markedPlaintify(marked)).parse(md)
 
   expect(plaintext).toMatchInlineSnapshot(`
     "GitHub Flavored Markdown (GFM) Specifications Demo

--- a/packages/plaintify/test/index.test.ts
+++ b/packages/plaintify/test/index.test.ts
@@ -59,7 +59,8 @@ it('should handle complex Markdown content', () => {
     Item 1
     Item 2
     Item 2a
-    Item 2b
+    Item 2b (bold)
+    Item 3 (italics)
 
     Ordered List
 


### PR DESCRIPTION
Hello! 👋

I'm using your library in a personal project,and I noticed it was crashing on Marked latest v13 version. So I decided to update it so it works well. It's helping me parse Markdown into plain text so I can embed it into a vector database for LLMs to retrieve it, so thank you for your work!

Seems Marked pushed breaking changes with the [v13 release](https://github.com/markedjs/marked/releases/tag/v13.0.0) and I tried to adapt it. Tests pass, for all packages (the only one failing was plaintify) so it seems good.

I had to introduce [a breaking change](https://github.com/bent10/marked-extensions/commit/b3f11f905c1f83d5bf5f9f62f6a34b6dd7b6c982), which is passing the Marked instance to the function. This seems necessary because the new way they're doing it calls the Parser instance ([old way](https://github.com/markedjs/marked/blob/c6a98ea66c36d12255543e2fabd8f8236dbc5276/src/Renderer.ts#L69)) vs ([new way](https://github.com/markedjs/marked/blob/master/src/Renderer.ts#L108)). However, if you know any way this breaking change could be avoided let me know!

There's also one Typescript error in some lines but we can know by the code that it's not an issue. Let me know if you want to just ignore it with `@ts-ignore` or find a better way so TS is happy.

This is my first open source contribution so sorry if I made anything wrong 🙏

Have a great day!