### PR TITLE
feat: Allow keeping original footnote references, fix links in back-references

### DIFF
--- a/packages/footnote/readme.md
+++ b/packages/footnote/readme.md
@@ -295,6 +295,8 @@ The marked-footnote extension accepts the following configuration options:
 
 - `footnoteDivider`: If set to `true`, it will insert a horizontal rule above the footnotes at the bottom of the page. Defaults to `false`.
 
+- `keepLabels`: If set to `true`, it will keep the original labels of footnote references in the generated HTML output. If not, the references will be labelled by numbers starting with 1 and incremented by 1 from left to right, top to down. Defaults to `false`.
+
 - `sectionClass`: The CSS class set to the element wrapping all footnotes at the bottom of the page. Can be set to an empty string to remove the CSS class. Defaults to `'footnotes'`.
 
 - `headingClass`: The CSS class set to the heading element introducing the footnotes at the bottom of the page for screen reader users. Can be set to an empty string to remove the CSS class. Defaults to `'sr-only'`.

--- a/packages/footnote/src/footnotes.ts
+++ b/packages/footnote/src/footnotes.ts
@@ -30,9 +30,17 @@ export function createFootnotes(
 
           refs.forEach((_, i) => {
             const ariaLabel = backRefLabel.replace('{0}', label)
-            footnoteItem += ` <a href="#${prefixId}ref-${encodedLabel}" data-${prefixId}backref aria-label="${ariaLabel}">${
-              i > 0 ? `↩<sup>${i + 1}</sup>` : '↩'
-            }</a>`
+            let textLabel: string
+            let idSuffix: string
+            if (i > 0) {
+              const displayIndex = i + 1
+              textLabel = `↩<sup>${displayIndex}</sup>`
+              idSuffix = `-${displayIndex}`
+            } else {
+              textLabel = '↩'
+              idSuffix = ''
+            }
+            footnoteItem += ` <a href="#${prefixId}ref-${encodedLabel}${idSuffix}" data-${prefixId}backref aria-label="${ariaLabel}">${textLabel}</a>`
           })
 
           footnoteItem += isEndsWithP ? '</p>\n' : '\n'

--- a/packages/footnote/src/index.ts
+++ b/packages/footnote/src/index.ts
@@ -14,6 +14,7 @@ export default function markedFootnote(options: Options = {}): MarkedExtension {
     description = 'Footnotes',
     refMarkers = false,
     footnoteDivider = false,
+    keepLabels = false,
     sectionClass = 'footnotes',
     headingClass = 'sr-only',
     backRefLabel = 'Back to reference {0}'
@@ -23,7 +24,7 @@ export default function markedFootnote(options: Options = {}): MarkedExtension {
   return {
     extensions: [
       createFootnote(lexer, description),
-      createFootnoteRef(prefixId, refMarkers),
+      createFootnoteRef(prefixId, refMarkers, keepLabels),
       createFootnotes(
         prefixId,
         prefixData,

--- a/packages/footnote/src/types.ts
+++ b/packages/footnote/src/types.ts
@@ -41,6 +41,13 @@ export interface Options {
   footnoteDivider?: boolean
 
   /**
+   * If set to `true`, it will keep the original labels of footnote references in the generated HTML output. If not, the references will be labelled by numbers starting with 1 and incremented by 1 from left to right, top to down.
+   *
+   * @default false
+   */
+  keepLabels?: boolean
+
+  /**
    * The CSS class set to the element wrapping all footnotes at the bottom of the page. Can be set to an empty string to remove the CSS class.
    *
    * @default 'footnotes'
@@ -89,6 +96,7 @@ export type Footnote = {
 export type FootnoteRef = {
   type: 'footnoteRef'
   raw: string
+  index: number
   id: string
   label: string
 }

--- a/packages/footnote/test/index.test.ts
+++ b/packages/footnote/test/index.test.ts
@@ -27,7 +27,8 @@ This is a sentence with custom options footnote[^1].
         prefixData: 'fn-',
         description: 'My footnotes',
         refMarkers: true,
-        footnoteDivider: true
+        footnoteDivider: true,
+        keepLabels: true
       })
     )
     .parse(md)
@@ -139,7 +140,7 @@ This is a sentence with an empty footnote[^1].
   expect(result2).toMatch(result1)
 })
 
-it('should handle footnote content with link', () => {
+it('should handle footnote content with link (and generate numeric reference labels)', () => {
   const md = `
 This is a sentence[^2] with an empty footnote[^1].
 
@@ -165,6 +166,32 @@ This is a sentence[^2] with an empty footnote[^1].
   `)
 })
 
+it('should handle footnote content with link (and keep the original reference labels)', () => {
+  const md = `
+This is a sentence[^2] with an empty footnote[^1].
+
+[^1]: foo <https://example.com>
+[^2]: bar [Foo](https://example.com)
+`
+  const html = marked.use(markedFootnote({ keepLabels: true })).parse(md)
+
+  expect(html).toMatchInlineSnapshot(`
+    "<p>This is a sentence<sup><a id="footnote-ref-2" href="#footnote-2" data-footnote-ref aria-describedby="footnote-label">2</a></sup> with an empty footnote<sup><a id="footnote-ref-1" href="#footnote-1" data-footnote-ref aria-describedby="footnote-label">1</a></sup>.</p>
+    <section class="footnotes" data-footnotes>
+    <h2 id="footnote-label" class="sr-only">Footnotes</h2>
+    <ol>
+    <li id="footnote-2">
+    <p>bar <a href="https://example.com">Foo</a> <a href="#footnote-ref-2" data-footnote-backref aria-label="Back to reference 2">↩</a></p>
+    </li>
+    <li id="footnote-1">
+    <p>foo <a href="https://example.com">https://example.com</a> <a href="#footnote-ref-1" data-footnote-backref aria-label="Back to reference 1">↩</a></p>
+    </li>
+    </ol>
+    </section>
+    "
+  `)
+})
+
 it('should handle multiple references to the same footnote', () => {
   const md = `
 This is a sentence with multiple references to the same footnote[^1][^1].
@@ -174,12 +201,12 @@ This is a sentence with multiple references to the same footnote[^1][^1].
   const html = marked.use(markedFootnote()).parse(md)
 
   expect(html).toMatchInlineSnapshot(`
-    "<p>This is a sentence with multiple references to the same footnote<sup><a id="footnote-ref-1" href="#footnote-1" data-footnote-ref aria-describedby="footnote-label">1</a></sup><sup><a id="footnote-ref-1" href="#footnote-1" data-footnote-ref aria-describedby="footnote-label">1</a></sup>.</p>
+    "<p>This is a sentence with multiple references to the same footnote<sup><a id="footnote-ref-1" href="#footnote-1" data-footnote-ref aria-describedby="footnote-label">1</a></sup><sup><a id="footnote-ref-1-2" href="#footnote-1" data-footnote-ref aria-describedby="footnote-label">1</a></sup>.</p>
     <section class="footnotes" data-footnotes>
     <h2 id="footnote-label" class="sr-only">Footnotes</h2>
     <ol>
     <li id="footnote-1">
-    <p>Content of the common footnote. <a href="#footnote-ref-1" data-footnote-backref aria-label="Back to reference 1">↩</a> <a href="#footnote-ref-1" data-footnote-backref aria-label="Back to reference 1">↩<sup>2</sup></a></p>
+    <p>Content of the common footnote. <a href="#footnote-ref-1" data-footnote-backref aria-label="Back to reference 1">↩</a> <a href="#footnote-ref-1-2" data-footnote-backref aria-label="Back to reference 1">↩<sup>2</sup></a></p>
     </li>
     </ol>
     </section>
@@ -398,19 +425,73 @@ This is the end of the file[^2].
   `)
 })
 
-it('should handle complex content within footnotes', () => {
+it('should handle complex content within footnotes (and generate numeric reference labels)', () => {
   const md = readFileSync('./test/fixtures/example.md', 'utf8')
   const html = marked.use(markedFootnote()).parse(md)
 
   expect(html).toMatchInlineSnapshot(`
     "<h1>Example</h1>
     <p>Here is a simple footnote<sup><a id="footnote-ref-1" href="#footnote-1" data-footnote-ref aria-describedby="footnote-label">1</a></sup>. With some additional text after it<sup><a id="footnote-ref-%40%23%24%25" href="#footnote-%40%23%24%25" data-footnote-ref aria-describedby="footnote-label">2</a></sup> and without disrupting the blocks<sup><a id="footnote-ref-bignote" href="#footnote-bignote" data-footnote-ref aria-describedby="footnote-label">3</a></sup>.</p>
-    <p><em>Navigating to the first footnote</em> <sup><a id="footnote-ref-1" href="#footnote-1" data-footnote-ref aria-describedby="footnote-label">1</a></sup></p>
+    <p><em>Navigating to the first footnote</em> <sup><a id="footnote-ref-1-2" href="#footnote-1" data-footnote-ref aria-describedby="footnote-label">1</a></sup></p>
     <section class="footnotes" data-footnotes>
     <h2 id="footnote-label" class="sr-only">Footnotes</h2>
     <ol>
     <li id="footnote-1">
-    <p>This is a footnote content. <a href="#footnote-ref-1" data-footnote-backref aria-label="Back to reference 1">↩</a> <a href="#footnote-ref-1" data-footnote-backref aria-label="Back to reference 1">↩<sup>2</sup></a></p>
+    <p>This is a footnote content. <a href="#footnote-ref-1" data-footnote-backref aria-label="Back to reference 1">↩</a> <a href="#footnote-ref-1-2" data-footnote-backref aria-label="Back to reference 1">↩<sup>2</sup></a></p>
+    </li>
+    <li id="footnote-%40%23%24%25">
+    <p>A footnote on the label: &quot;@#$%&quot;. <a href="#footnote-ref-%40%23%24%25" data-footnote-backref aria-label="Back to reference @#$%">↩</a></p>
+    </li>
+    <li id="footnote-bignote">
+    <p>The first paragraph of the definition.</p>
+    <p>Paragraph two of the definition.</p>
+    <blockquote>
+    <p>A blockquote with
+    multiple lines.</p>
+    </blockquote>
+    <pre><code>a code block
+    </code></pre>
+    <table>
+    <thead>
+    <tr>
+    <th>Header 1</th>
+    <th>Header 2</th>
+    </tr>
+    </thead>
+    <tbody><tr>
+    <td>Cell 1</td>
+    <td>Cell 2</td>
+    </tr>
+    </tbody></table>
+    <p>A <code>final</code> paragraph before list.</p>
+    <ul>
+    <li>Item 1</li>
+    <li>Item 2<ul>
+    <li>Subitem 1</li>
+    <li>Subitem 2</li>
+    </ul>
+    </li>
+    </ul> <a href="#footnote-ref-bignote" data-footnote-backref aria-label="Back to reference bignote">↩</a>
+    </li>
+    </ol>
+    </section>
+    "
+  `)
+})
+
+it('should handle complex content within footnotes (and keep the original reference labels)', () => {
+  const md = readFileSync('./test/fixtures/example.md', 'utf8')
+  const html = marked.use(markedFootnote({ keepLabels: true })).parse(md)
+
+  expect(html).toMatchInlineSnapshot(`
+    "<h1>Example</h1>
+    <p>Here is a simple footnote<sup><a id="footnote-ref-1" href="#footnote-1" data-footnote-ref aria-describedby="footnote-label">1</a></sup>. With some additional text after it<sup><a id="footnote-ref-%40%23%24%25" href="#footnote-%40%23%24%25" data-footnote-ref aria-describedby="footnote-label">@#$%</a></sup> and without disrupting the blocks<sup><a id="footnote-ref-bignote" href="#footnote-bignote" data-footnote-ref aria-describedby="footnote-label">bignote</a></sup>.</p>
+    <p><em>Navigating to the first footnote</em> <sup><a id="footnote-ref-1-2" href="#footnote-1" data-footnote-ref aria-describedby="footnote-label">1</a></sup></p>
+    <section class="footnotes" data-footnotes>
+    <h2 id="footnote-label" class="sr-only">Footnotes</h2>
+    <ol>
+    <li id="footnote-1">
+    <p>This is a footnote content. <a href="#footnote-ref-1" data-footnote-backref aria-label="Back to reference 1">↩</a> <a href="#footnote-ref-1-2" data-footnote-backref aria-label="Back to reference 1">↩<sup>2</sup></a></p>
     </li>
     <li id="footnote-%40%23%24%25">
     <p>A footnote on the label: &quot;@#$%&quot;. <a href="#footnote-ref-%40%23%24%25" data-footnote-backref aria-label="Back to reference @#$%">↩</a></p>


### PR DESCRIPTION
This change attempts to fix #177 and #167.

1) Let's introduce a new option to the `markedFootnote` extension function:

- `keepLabels`: If set to `true`, it will keep the original labels of footnote references in the generated HTML output. If not, the references will be labelled by numbers starting with 1 and incremented by 1 from left to right, top to down. Defaults to `false`.

The default behaviour doesn't change.

2) Let's append suffixes to additional references to the same footnote.

- If there's just one reference to a footnote, let the ID of the link be `footnote-ref-{L}`, where `{L} is the encoded label of the footnote reference.
- If there're more than one references to the same footnote, let the ID of the first link be `footnote-ref-{L}` and of the following links `footnote-ref-{L}-{N}` , where `{L} is the encoded label of the footnote reference and `{N}` the number of the following reference, starting with 2.

For example,

    footnote-ref-1
    footnote-ref-1-2
    footnote-ref-1-3
    ...

This might be seen as a both an unavoidable bugfix and as a breaking change. The IDs of the footnote references won't be `footnote-ref-{L}` any more, if more footnote references point the same footnote. but using the same ID in multiple elements causes the HTML to be invalid.

I tried not to change anything in the most most often case - each footnote has just one reference. The ID remains the same in that case, because the HTML is valid in that case and technically, there's no need to change anything.